### PR TITLE
Fixed "e.data.split is not a function" error

### DIFF
--- a/webroot/user/caller.js
+++ b/webroot/user/caller.js
@@ -75,6 +75,10 @@ var haveBeenWaitingForCalleeOnline=false;
 var lastOnlineStatus = "";
 
 var extMessage = function(e) {
+	// prevent an error on split() below when extensions send unrelated, non-string message events to the window
+	if(typeof e.data !== 'string') {
+		return;
+	}
 	var data = e.data.split(':')
 	var action = data[0];
 	var actionArg = data[1];

--- a/webroot/user/caller.js
+++ b/webroot/user/caller.js
@@ -75,7 +75,7 @@ var haveBeenWaitingForCalleeOnline=false;
 var lastOnlineStatus = "";
 
 var extMessage = function(e) {
-	// prevent an error on split() below when extensions send unrelated, non-string message events to the window
+	// prevent an error on split() below when extensions emit unrelated, non-string 'message' events to the window
 	if(typeof e.data !== 'string') {
 		return;
 	}


### PR DESCRIPTION
I noticed this error was being thrown only when I wasn't in incognito mode, and after investigating it further I narrowed it down to the MetaMask Chrome extension.

![image](https://user-images.githubusercontent.com/75134774/153785354-ece805dc-0c08-49c8-96dd-b267066daff0.png)

On `caller.js`, the `extMessage` function gets subscribed to receive `message` events from the window:
```js
window.addEventListener('message', extMessage, false);
```
..and it seems that MetaMask (and probably other extensions as well) emit such events (a JSON object in this case), which might cause errors.

The fix was to simply check if `e.data` is a string and return early if it isn't. I tested this directly in the browser using Overrides and it fixed the problem.  :)

Unfortunately I couldn't get `extMessage()` to be called internally so I couldn't 100% verify that it works, but I'm confident this won't break anything.